### PR TITLE
Release for v0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.0.4](https://github.com/handlename/protoc-gen-oas2connect/compare/v0.0.3...v0.0.4) - 2024-06-11
+- Support optional (really) by @handlename in https://github.com/handlename/protoc-gen-oas2connect/pull/9
+
 ## [v0.0.3](https://github.com/handlename/protoc-gen-oas2connect/compare/v0.0.2...v0.0.3) - 2024-06-10
 - Migrate buf config in examples to v2 by @handlename in https://github.com/handlename/protoc-gen-oas2connect/pull/5
 - Support "optional" by @handlename in https://github.com/handlename/protoc-gen-oas2connect/pull/7

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package o2c
 
-const version = "0.0.3"
+const version = "0.0.4"


### PR DESCRIPTION
This pull request is for the next release as v0.0.4 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.0.4 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.3" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Support optional (really) by @handlename in https://github.com/handlename/protoc-gen-oas2connect/pull/9


**Full Changelog**: https://github.com/handlename/protoc-gen-oas2connect/compare/v0.0.3...v0.0.4