### PR TITLE
Release for v0.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.0.8](https://github.com/handlename/protoc-gen-oas2connect/compare/v0.0.7...v0.0.8) - 2024-08-22
+- request body may be nil by @handlename in https://github.com/handlename/protoc-gen-oas2connect/pull/19
+
 ## [v0.0.7](https://github.com/handlename/protoc-gen-oas2connect/compare/v0.0.6...v0.0.7) - 2024-08-22
 - accept cameCased field name in request message by @handlename in https://github.com/handlename/protoc-gen-oas2connect/pull/16
 - format generated codes by @handlename in https://github.com/handlename/protoc-gen-oas2connect/pull/18

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package o2c
 
-const version = "0.0.7"
+const version = "0.0.8"


### PR DESCRIPTION
This pull request is for the next release as v0.0.8 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.0.8 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.7" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* request body may be nil by @handlename in https://github.com/handlename/protoc-gen-oas2connect/pull/19


**Full Changelog**: https://github.com/handlename/protoc-gen-oas2connect/compare/v0.0.7...v0.0.8